### PR TITLE
Update installation command not to use sudo

### DIFF
--- a/install.md
+++ b/install.md
@@ -5,7 +5,7 @@ The easiest way to install Pharos Cluster executables is to use [chpharos](https
 
 **1. Install chpharos**
 ```
-curl -s https://get.pharos.sh | sudo bash
+curl -s https://get.pharos.sh | bash
 ```
 
 or via MacOS Homebrew


### PR DESCRIPTION
Using sudo causes brew install to fail, now installation script prompts for sudo access if required.
See: https://github.com/kontena/get-pharos-sh/pull/23